### PR TITLE
Switch build to rollup

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,8 @@ camelCase for function and variable names
 
 - Pull the repo
 - run `npm install`
-- run `npm start` to run all unit tests, lint the codebase, and build the API docs
+- run `npm test` to run all unit tests
+- run `npm run build` to bundle the library with Rollup
 
 * * *
 

--- a/README.source.md
+++ b/README.source.md
@@ -32,7 +32,8 @@ camelCase for function and variable names
 
 - Pull the repo
 - run `npm install`
-- run `npm start` to run all unit tests, lint the codebase, and build the API docs
+- run `npm test` to run all unit tests
+- run `npm run build` to bundle the library with Rollup
 
 * * *
 

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   "source": "modules/index.js",
   "scripts": {
     "coverage": "nyc --reporter=text-lcov npm test > coverage.lcov",
-    "build": "microbundle --name blue",
-    "dev": "microbundle watch",
+    "build": "rollup -c",
+    "dev": "rollup -c -w",
     "test": "mocha --require @babel/register ./modules/*/__tests__/*.js",
     "docs": "jsdoc2md --template README.source.md modules/**/*.js > README.md",
     "prepublishOnly": "npm run build && npm test && npm run docs"
@@ -39,7 +39,8 @@
     "chai": "^4.1.2",
     "jsdoc-to-markdown": "^4.0.1",
     "jsdom": "^13.2.0",
-    "microbundle": "^0.10.0",
+    "rollup": "^4.0.0",
+    "rollup-plugin-terser": "^7.0.2",
     "mocha": "^6.0.0",
     "mocha-jsdom": "^2.0.0",
     "nyc": "^13.3.0"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,11 @@
+import { terser } from 'rollup-plugin-terser';
+
+export default {
+  input: 'modules/index.js',
+  output: [
+    { file: 'dist/blue.js', format: 'cjs' },
+    { file: 'dist/blue.mjs', format: 'esm' },
+    { file: 'dist/blue.umd.js', format: 'umd', name: 'blue' }
+  ],
+  plugins: [terser()]
+};


### PR DESCRIPTION
## Summary
- replace microbundle with rollup
- update contribution docs with new build instructions
- add a basic `rollup.config.js`

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841f56446f48333bb73f92d00499bcc